### PR TITLE
Initialize RealAcceleration

### DIFF
--- a/src/GDTFManager.cpp
+++ b/src/GDTFManager.cpp
@@ -3747,6 +3747,7 @@ GdtfDmxChannelFunction::GdtfDmxChannelFunction(GdtfDmxLogicalChannel* parent)
 	fPhysicalStart			= 0;
 	fPhysicalEnd			= 1;
 	fRealFade				= 0;
+	fRealAcceleration 		= 0;
 	fOnWheel				= nullptr;
 	fEmitter				= nullptr;
 	fAttribute				= nullptr;
@@ -3770,7 +3771,7 @@ GdtfDmxChannelFunction::GdtfDmxChannelFunction(const TXString& name, GdtfDmxLogi
 	fPhysicalStart			= 0;
 	fPhysicalEnd			= 1;
 	fRealFade				= 0;
-	fRealAcceleration = 0;
+	fRealAcceleration 		= 0;
 	fOnWheel				= nullptr;
 	fEmitter				= nullptr;				
 	fAttribute				= nullptr;


### PR DESCRIPTION
## Pullrequest :tada::tada::tada:

One of the 2 constructors didn't initialize the realAcceleration.