### PR TITLE
Bug-FIx-62-Library-doesnt-have-provider-providerVersion

### DIFF
--- a/.github/actions/build-ubuntu/action.yml
+++ b/.github/actions/build-ubuntu/action.yml
@@ -22,7 +22,7 @@ runs:
       run: |
         mkdir xerces-c
         cd xerces-c
-        curl -o xerces-c.zip https://dlcdn.apache.org//xerces/c/3/sources/xerces-c-3.2.5.zip
+        curl -o xerces-c.zip https://dlcdn.apache.org//xerces/c/3/sources/xerces-c-3.3.0.zip
         unzip xerces-c.zip -d . && mv xerces-c-*/* .
 
     # libMVRGdtf expects XMLChar be uint16_t

--- a/src/Implementation/CMediaRessourceVectorImpl.cpp
+++ b/src/Implementation/CMediaRessourceVectorImpl.cpp
@@ -23,7 +23,6 @@ SceneData::SceneDataExchange* VectorworksMVR::CMediaRessourceVectorImpl::GetExch
 	return & fExchangeObj;
 }
 
-
 VectorworksMVR::VCOMError VectorworksMVR::CMediaRessourceVectorImpl::AddFileToMvrFile(MvrString fullPath)
 {
     TXString strFullPath(fullPath);
@@ -72,6 +71,17 @@ VectorworksMVR::VCOMError VectorworksMVR::CMediaRessourceVectorImpl::AddGdtfFold
 	
 	
 	return kVCOMError_NoError;
+}
+
+VectorworksMVR::VCOMError VectorworksMVR::CMediaRessourceVectorImpl::AddProviderAndProviderVersion( MvrString provider, MvrString providerVersion )
+{
+	TXString strProvider(provider);
+	TXString strProviderVersion(providerVersion);
+	
+	fExchangeObj.AddProviderAndProviderVersion(strProvider, strProviderVersion);
+	
+	return kVCOMError_NoError;
+
 }
 
 VectorworksMVR::VCOMError VectorworksMVR::CMediaRessourceVectorImpl::OpenForWrite(MvrString fullPath)

--- a/src/Implementation/CMediaRessourceVectorImpl.h
+++ b/src/Implementation/CMediaRessourceVectorImpl.h
@@ -43,7 +43,8 @@ namespace VectorworksMVR
 		virtual VCOMError VCOM_CALLTYPE	AddGdtfFolderLocation(MvrString fullPathToFolder);
         virtual VCOMError VCOM_CALLTYPE	AddFileToMvrFile(MvrString fullPath);
 		virtual VCOMError VCOM_CALLTYPE AddBufferToMvrFile(MvrString filename, char* buffer, size_t length);
-		
+		virtual VCOMError VCOM_CALLTYPE	AddProviderAndProviderVersion( MvrString provider, MvrString providerVersion );
+
 		// After this you can generate Aux Objects
 		virtual VCOMError VCOM_CALLTYPE		CreateDataProviderObject(		MvrString provider,		MvrString version, 	ISceneDataProvider** outSceneDataProvider);
 		virtual VCOMError VCOM_CALLTYPE		CreatePositionObject(	 		const MvrUUID& guid,	MvrString name,		IPosition** outPositionObj);

--- a/src/Include/IMediaRessourceVectorInterface.h
+++ b/src/Include/IMediaRessourceVectorInterface.h
@@ -395,7 +395,8 @@ namespace VectorworksMVR
 		virtual VCOMError VCOM_CALLTYPE		AddGdtfFolderLocation(MvrString fullPathToFolder) = 0;
         virtual VCOMError VCOM_CALLTYPE		AddFileToMvrFile(MvrString fullPath) = 0;
 		virtual VCOMError VCOM_CALLTYPE		AddBufferToMvrFile(MvrString filename, char* buffer, size_t length) = 0;
-		
+		virtual VCOMError VCOM_CALLTYPE		AddProviderAndProviderVersion( MvrString provider, MvrString providerVersion ) = 0;
+
 		// After this you can generate Aux Objects
 		virtual VCOMError VCOM_CALLTYPE		CreateDataProviderObject(		MvrString provider,		MvrString version,	ISceneDataProvider** outSceneDataProvider) = 0;
 		virtual VCOMError VCOM_CALLTYPE		CreatePositionObject(	 		const MvrUUID& guid,	MvrString name,		IPosition** outPositionObj) = 0;

--- a/src/Prefix/CommonPrefix.h
+++ b/src/Prefix/CommonPrefix.h
@@ -62,6 +62,8 @@
 #define XML_Val_RootNodeName			"GeneralSceneDescription"
 #define XML_Val_RootAttrMainVersion		"verMajor"
 #define XML_Val_RootAttrMinorVersion	"verMinor"
+#define XML_Val_RootAttrProvider		"provider"
+#define XML_Val_RootAttrProviderVersion	"providerVersion"
 
 #define XML_Val_UserDataNodeName		"UserData"
 #define XML_Val_UserDataVWEntry			"VWEntry"

--- a/src/SceneDataExchange.cpp
+++ b/src/SceneDataExchange.cpp
@@ -3377,6 +3377,12 @@ bool SceneDataExchange::WriteToFile(const IFileIdentifierPtr& file)
 	return true;
 }
 
+void SceneDataExchange::AddProviderAndProviderVersion(const TXString& provider, const TXString& providerVersion)
+{
+	fProvider = provider;
+	fProviderVersion = providerVersion;
+}
+
 bool SceneDataExchange::WriteXml(const IFolderIdentifierPtr& folder, IXMLFileIOBufferImpl& outBuffer)
 {
     
@@ -3395,8 +3401,10 @@ bool SceneDataExchange::WriteXml(const IFolderIdentifierPtr& folder, IXMLFileIOB
 		{
 			//-------------------------------------------------------------------------------------------------
 			// Set Version for the export Format
-			pDatabaseRoot->SetNodeAttributeValue(XML_Val_RootAttrMainVersion,	TXString() << kMVR_MajorVersion);
-			pDatabaseRoot->SetNodeAttributeValue(XML_Val_RootAttrMinorVersion,	TXString() << kMVR_MinorVersion);
+			pDatabaseRoot->SetNodeAttributeValue(XML_Val_RootAttrMainVersion,		TXString() << kMVR_MajorVersion);
+			pDatabaseRoot->SetNodeAttributeValue(XML_Val_RootAttrMinorVersion,		TXString() << kMVR_MinorVersion);
+			pDatabaseRoot->SetNodeAttributeValue(XML_Val_RootAttrProvider,			fProvider);
+			pDatabaseRoot->SetNodeAttributeValue(XML_Val_RootAttrProviderVersion,	fProviderVersion);
 			
 			
 			//-------------------------------------------------------------------------------------------------

--- a/src/SceneDataExchange.h
+++ b/src/SceneDataExchange.h
@@ -991,6 +991,8 @@ namespace SceneData
 		
 		//
 		size_t							fCountExportedGeometryProviders;
+		TXString						fProvider;
+		TXString						fProviderVersion;
 
 		//Duplicated Uuids flag
 		bool fDuplicatedUuids;
@@ -1068,7 +1070,8 @@ namespace SceneData
         void AddFileToZip(const IFileIdentifierPtr& file, ERessourceType resType);
 		void AddBufferToZip(const TXString& fileName, ISceneDataZipBuffer* buffer);
 		void AddLocationForGdtfFiles(IFolderIdentifierPtr folder);
-		
+		void AddProviderAndProviderVersion(const TXString& provider, const TXString& providerVersion );
+
 	private:
 		
 		bool WriteXml(const IFolderIdentifierPtr& folder , IXMLFileIOBufferImpl& outBuffer);


### PR DESCRIPTION
Issue:
- #62 

Issue fix:
 - Created a function that applies provider and providerVersion on root node
 
Github Actions Fix:
I found that version is no more available from link which was in build-ubuntu, which was causing fail on Github Test Action on Build stage

![image](https://github.com/user-attachments/assets/90edb974-42ee-4fd8-ad81-8b153fa821b3)

Then I checked that is only available xerces 3.3.0 for download and changed it in github actions
