### PR TITLE
Fixing typo in CGdtfMacro.cpp

### DIFF
--- a/src/Implementation/CGdtfMacro.cpp
+++ b/src/Implementation/CGdtfMacro.cpp
@@ -219,7 +219,7 @@ VectorworksMVR::VCOMError VectorworksMVR::CGdtfMacroImpl::GetMacroDMX(IGdtfMacro
 	if ( *outMacroDmx)
 	{
 		(*outMacroDmx)->Release();
-		 outMacroDmx = NULL;
+		 *outMacroDmx = NULL;
 	}
 	
 	//---------------------------------------------------------------------------


### PR DESCRIPTION
Issue:
- #66 

Fixing:

Changing from outMacroDmx to *outMacroDmx