### PR TITLE
[HasDefaultValue]

### DIFF
--- a/src/GDTFManager.cpp
+++ b/src/GDTFManager.cpp
@@ -5803,6 +5803,7 @@ GdtfDmxChannel* GdtfDmxLogicalChannel::GetParentDMXChannel() const
 GdtfDmxChannelFunction::GdtfDmxChannelFunction(GdtfDmxLogicalChannel* parent)
 {
 	fDefaultValue			= 0;
+	fDefaultValueNone       = true;
 	fAdressStart			= 0;
 	fPhysicalStart			= 0;
 	fPhysicalEnd			= 1;
@@ -5837,6 +5838,7 @@ GdtfDmxChannelFunction::GdtfDmxChannelFunction(const TXString& name, GdtfDmxLogi
 {
 	fName					= name;
 	fDefaultValue			= 0;
+	fDefaultValueNone       = true;
 	fAdressStart			= 0;
 	fPhysicalStart			= 0;
 	fPhysicalEnd			= 1;
@@ -5897,6 +5899,7 @@ void GdtfDmxChannelFunction::SetOriginalAttribute(const TXString &attribute)
 void GdtfDmxChannelFunction::SetDefaultValue(DmxValue defaultValue)
 {
 	fDefaultValue = defaultValue;
+	fDefaultValueNone = false;
 }
 
 void GdtfDmxChannelFunction::SetStartAddress(DmxValue address)
@@ -5950,7 +5953,7 @@ void GdtfDmxChannelFunction::OnPrintToFile(IXMLFileNodePtr pNode)
 	// Print node attributes
 	pNode->SetNodeAttributeValue(XML_GDTF_DMXChannelFuntionName,				fName);
 
-	pNode->SetNodeAttributeValue(XML_GDTF_DMXChannelFuntionDefault,				GdtfConverter::ConvertDMXValue(fDefaultValue, chanelReso));
+	pNode->SetNodeAttributeValue(XML_GDTF_DMXChannelFuntionDefault,                GdtfConverter::ConvertDMXValue(fDefaultValue, chanelReso, fDefaultValueNone));
 	pNode->SetNodeAttributeValue(XML_GDTF_DMXChannelFuntionDMXFrom,				GdtfConverter::ConvertDMXValue(fAdressStart, chanelReso));
 	pNode->SetNodeAttributeValue(XML_GDTF_DMXChannelFuntionPhysicalFrom,		GdtfConverter::ConvertDouble(fPhysicalStart));
 	pNode->SetNodeAttributeValue(XML_GDTF_DMXChannelFuntionPhysicalTo,			GdtfConverter::ConvertDouble(fPhysicalEnd));
@@ -6077,7 +6080,9 @@ void GdtfDmxChannelFunction::OnReadFromNode(const IXMLFileNodePtr& pNode)
 
 							pNode->GetNodeAttributeValue(XML_GDTF_DMXChannelFuntionName,				fName);
 							pNode->GetNodeAttributeValue(XML_GDTF_DMXChannelFuntionOriginalAttribute,	fOrignalAttribute);
-	TXString defaultValue;	pNode->GetNodeAttributeValue(XML_GDTF_DMXChannelFuntionDefault,				defaultValue);		GdtfConverter::ConvertDMXValue(defaultValue,	pNode,	channelReso,fDefaultValue);
+	TXString defaultValue;
+    if(VCOM_SUCCEEDED(pNode->GetNodeAttributeValue(XML_GDTF_DMXChannelFuntionDefault, defaultValue)))
+        GdtfConverter::ConvertDMXValue(defaultValue, pNode, channelReso, fDefaultValue, fDefaultValueNone);
 	TXString dmxFrom;		pNode->GetNodeAttributeValue(XML_GDTF_DMXChannelFuntionDMXFrom,				dmxFrom);			GdtfConverter::ConvertDMXValue(dmxFrom, 		pNode,	channelReso,fAdressStart);
 	TXString physFrom;		pNode->GetNodeAttributeValue(XML_GDTF_DMXChannelFuntionPhysicalFrom,		physFrom);			GdtfConverter::ConvertDouble(physFrom, 			pNode,				fPhysicalStart);
 	TXString physTo;		pNode->GetNodeAttributeValue(XML_GDTF_DMXChannelFuntionPhysicalTo,			physTo);			GdtfConverter::ConvertDouble(physTo, 			pNode,				fPhysicalEnd);
@@ -6248,6 +6253,11 @@ const TXString& GdtfDmxChannelFunction::GetOriginalAttribute()
 DmxValue GdtfDmxChannelFunction::GetDefaultValue() const
 {
 	return fDefaultValue;
+}
+
+bool GdtfDmxChannelFunction::HasDefaultValue() const
+{
+    return !fDefaultValueNone;
 }
 
 DmxValue GdtfDmxChannelFunction::GetStartAdress() const

--- a/src/GDTFManager.h
+++ b/src/GDTFManager.h
@@ -1628,6 +1628,7 @@ namespace SceneData
 		GdtfAttribute*		    fAttribute;
 		TXString				fOrignalAttribute;
 		DmxValue				fDefaultValue;
+		bool					fDefaultValueNone;
 		DmxValue				fAdressStart;
 		double					fPhysicalStart;
 		double					fPhysicalEnd;
@@ -1676,6 +1677,7 @@ namespace SceneData
         GdtfAttribute*				    GetAttribute();
 		const TXString&					GetOriginalAttribute();
 		DmxValue						GetDefaultValue() const;
+		bool							HasDefaultValue() const;
         DmxValue						GetStartAdress() const;
         DmxValue						GetEndAdress() const;
         double							GetPhysicalStart() const;

--- a/src/Implementation/CGdtfDmxChannelFunction.cpp
+++ b/src/Implementation/CGdtfDmxChannelFunction.cpp
@@ -101,6 +101,16 @@ VectorworksMVR::VCOMError VectorworksMVR::CGdtfDmxChannelFunctionImpl::GetDefaul
     return kVCOMError_NoError;
 }
 
+VectorworksMVR::VCOMError VectorworksMVR::CGdtfDmxChannelFunctionImpl::HasDefaultValue(bool &defaultValue)
+{
+	// Check Pointer
+	if ( ! fFunction) { return kVCOMError_NotInitialized; }
+	
+	defaultValue = fFunction->HasDefaultValue();
+	
+	return kVCOMError_NoError;
+}
+
 VectorworksMVR::VCOMError VectorworksMVR::CGdtfDmxChannelFunctionImpl::GetStartAddress(DmxValue& address)
 {
 	// Check Pointer

--- a/src/Implementation/CGdtfDmxChannelFunction.h
+++ b/src/Implementation/CGdtfDmxChannelFunction.h
@@ -19,6 +19,7 @@ namespace VectorworksMVR
         virtual VCOMError VCOM_CALLTYPE     GetAttribute(IGdtfAttribute** attribute);
         virtual MvrString VCOM_CALLTYPE     GetOriginalAttribute();
         virtual VCOMError VCOM_CALLTYPE     GetDefaultValue(DmxValue& defaultValue);
+		virtual VCOMError VCOM_CALLTYPE     HasDefaultValue(bool& defaultValue);
         virtual VCOMError VCOM_CALLTYPE     GetStartAddress(DmxValue& address);
         virtual VCOMError VCOM_CALLTYPE     GetEndAddress(DmxValue& address);
         virtual VCOMError VCOM_CALLTYPE     GetPhysicalStart(double& start);

--- a/src/Include/IMediaRessourceVectorInterface.h
+++ b/src/Include/IMediaRessourceVectorInterface.h
@@ -1074,6 +1074,8 @@ namespace VectorworksMVR
 		virtual VCOMError VCOM_CALLTYPE     GetDmxSubChannelSetCount(size_t& count) = 0;
         virtual VCOMError VCOM_CALLTYPE     GetDmxSubChannelSetAt(size_t at, IGdtfDmxSubChannelSet** subChannelSet) = 0;
 		virtual VCOMError VCOM_CALLTYPE     CreateDmxSubChannelSet(MvrString name, IGdtfSubPhysicalUnit* subPhysicalUnit, IGdtfDmxSubChannelSet** subChannelSet) = 0;
+
+		virtual VCOMError VCOM_CALLTYPE     HasDefaultValue(bool& defaultValue) = 0;
     };
 	typedef VCOMPtr<IGdtfDmxChannelFunction>	IGdtfDmxChannelFunctionPtr;
         


### PR DESCRIPTION
We at Chamsys/Chauvet would really benefit from the addition of a HasDefaultValue() function on the IGdtfDmxChannelFunction interface. At present 0 (zero) is returned if there is a DefaultValue set to 0, or if there is no DefaultValue. If there is no DefaultValue we would then want to assign our own default value - depending on the Channel's attribute.

My code enhancement is based on the already existing IGdtfDmxChannel HasHighlight() function.