### PR TITLE
Adding Aspect Ratio to Display 

### DIFF
--- a/src/GDTFManager.cpp
+++ b/src/GDTFManager.cpp
@@ -2877,12 +2877,14 @@ GdtfGeometryDisplay::GdtfGeometryDisplay(GdtfGeometry* parent)
 					:GdtfGeometry(parent)
 {
 	fTexture = "";
+	fAspectRatio = "";
 }
 
 GdtfGeometryDisplay::GdtfGeometryDisplay(const TXString& name, GdtfModelPtr refToModel,const VWTransformMatrix& ma, GdtfGeometry* parent) 
 					:GdtfGeometry(name,refToModel,ma, parent)
 {
-	fTexture = "";	
+	fTexture = "";
+	fAspectRatio = "";
 }
 
 GdtfGeometryDisplay::~GdtfGeometryDisplay()
@@ -2899,12 +2901,22 @@ void GdtfGeometryDisplay::SetTexture(const TXString& texture)
 	fTexture = texture;
 }
 
+const TXString& GdtfGeometryDisplay::GetAspectRatio() const
+{
+	return fAspectRatio;
+}
+
+void GdtfGeometryDisplay::SetAspectRatio( const TXString& aspectRatio )
+{
+	fAspectRatio = aspectRatio;
+}
 void GdtfGeometryDisplay::OnPrintToFile(IXMLFileNodePtr pNode) 
 {
 	//------------------------------------------------------------------------------------
 	// Call the parent
 	GdtfGeometry::OnPrintToFile(pNode);
-	pNode->SetNodeAttributeValue(XML_GDTF_DisplayTexture, fTexture);
+	pNode->SetNodeAttributeValue( XML_GDTF_DisplayTexture, fTexture);
+	pNode->SetNodeAttributeValue( XML_GDTF_DisplayAspectRatio, fAspectRatio );
 }
 
 void GdtfGeometryDisplay::OnReadFromNode(const IXMLFileNodePtr& pNode)
@@ -2913,7 +2925,8 @@ void GdtfGeometryDisplay::OnReadFromNode(const IXMLFileNodePtr& pNode)
 	// Call the parent
 	GdtfGeometry::OnReadFromNode(pNode);
 
-	pNode->GetNodeAttributeValue(XML_GDTF_DisplayTexture, fTexture);
+	pNode->GetNodeAttributeValue( XML_GDTF_DisplayTexture, fTexture);
+	pNode->GetNodeAttributeValue( XML_GDTF_DisplayAspectRatio, fAspectRatio );
 }
 
 void GdtfGeometryDisplay::OnErrorCheck(const IXMLFileNodePtr& pNode)

--- a/src/GDTFManager.h
+++ b/src/GDTFManager.h
@@ -990,12 +990,15 @@ namespace SceneData
 	
 	private:
 		TXString	fTexture;
+		TXString    fAspectRatio;
 
 	public:
 		virtual EGdtfObjectType			GetObjectType();
 		const TXString&	GetTexture();
+		const TXString& GetAspectRatio() const;
 
 		void			SetTexture(const TXString& texture);
+		void			SetAspectRatio( const TXString& aspectRatio );
 
 	protected:
 		virtual	TXString				GetNodeName();

--- a/src/Implementation/CGdtfGeometry.cpp
+++ b/src/Implementation/CGdtfGeometry.cpp
@@ -980,6 +980,31 @@ VectorworksMVR::VCOMError VectorworksMVR::CGdtfGeometryImpl::SetTexture(MvrStrin
 	return kVCOMError_NoError;
 }
 
+MvrString VectorworksMVR::CGdtfGeometryImpl::GetAspectRatio() 
+{
+	if(!fGeometry) return "";
+
+	if( fGeometryType != EGdtfObjectType::eGdtfGeometryDisplay) return "";
+
+	SceneData::GdtfGeometryDisplayPtr display = static_cast<SceneData::GdtfGeometryDisplayPtr>(fGeometry);
+	if(!display) return "";
+
+	return display->GetAspectRatio().GetCharPtr();
+}
+
+VectorworksMVR::VCOMError VectorworksMVR::CGdtfGeometryImpl::SetAspectRatio(MvrString aspectRatio)
+{
+	if (!fGeometry) return kVCOMError_NotInitialized;
+
+	if( fGeometryType != EGdtfObjectType::eGdtfGeometryDisplay) return kVCOMError_WrongGeometryType;
+
+	SceneData::GdtfGeometryDisplayPtr display = static_cast<SceneData::GdtfGeometryDisplayPtr>(fGeometry);
+	if(!display) return kVCOMError_Failed;
+
+	display->SetAspectRatio(aspectRatio);
+	return kVCOMError_NoError;
+}
+
 VectorworksMVR::VCOMError VectorworksMVR::CGdtfGeometryImpl::GetCountLinkedDmxChannel(size_t& count, IGdtfDmxMode * forMode)
 {
 	// Get Count

--- a/src/Implementation/CGdtfGeometry.h
+++ b/src/Implementation/CGdtfGeometry.h
@@ -65,7 +65,10 @@ namespace VectorworksMVR
 
         // Display
 		virtual MvrString VCOM_CALLTYPE		GetTexture();
-		virtual VCOMError VCOM_CALLTYPE		SetTexture(MvrString texture);
+        virtual MvrString VCOM_CALLTYPE		GetAspectRatio();
+        virtual VCOMError VCOM_CALLTYPE		SetTexture(MvrString texture);
+		virtual VCOMError VCOM_CALLTYPE		SetAspectRatio(MvrString aspectRatio);
+
 
         // Helpers
         virtual VCOMError VCOM_CALLTYPE     GetCountLinkedDmxChannel(size_t& count, IGdtfDmxMode * forMode);

--- a/src/Include/IMediaRessourceVectorInterface.h
+++ b/src/Include/IMediaRessourceVectorInterface.h
@@ -818,7 +818,10 @@ namespace VectorworksMVR
 
 		// Display
 		virtual MvrString VCOM_CALLTYPE		GetTexture() = 0;
+		virtual MvrString VCOM_CALLTYPE		GetAspectRatio() = 0;
+
 		virtual VCOMError VCOM_CALLTYPE		SetTexture(MvrString texture) = 0;
+		virtual VCOMError VCOM_CALLTYPE		SetAspectRatio(MvrString aspectRatio) = 0;
 
 		// GDTF 1.2
 		// Lamp

--- a/src/Prefix/CommonPrefix.h
+++ b/src/Prefix/CommonPrefix.h
@@ -429,6 +429,7 @@ const Sint32 kMVR_MinorVersion = 5;
 
 #define XML_GDTF_DisplayNodeName                "Display"
 #define XML_GDTF_DisplayTexture                 "Texture"
+#define XML_GDTF_DisplayAspectRatio				"AspectRatio"
 
 #define XML_GDTF_LaserProtocolNodeName          "Protocol"
 #define XML_GDTF_LaserProtocolName              "Name"


### PR DESCRIPTION
Adding parameters for Display geometry object

Issue:
The Display object was not containing the Aspect Ratio of the screen.