### PR TITLE
macOS build failure with libc++ 19

### DIFF
--- a/src/GSString.h
+++ b/src/GSString.h
@@ -49,10 +49,8 @@ enum class ETXEncoding {
 // TXString character type
 #if GS_WIN
 typedef wchar_t TXChar;
-#elif GS_LIN
-typedef char16_t TXChar;
 #else
-typedef UniChar TXChar;
+typedef char16_t TXChar;
 #endif
 
 // StdUStr definition


### PR DESCRIPTION
 libMVRgdtf fails to build on macOS with Homebrew LLVM 19:

 error: implicit instantiation of undefined template 'std::char_traits<unsigned short>'

 On macOS, TXChar is UniChar (uint16_t), so StdUStr becomes std::basic_string<uint16_t>. libc++ 19 no longer provides std::char_traits for arbitrary types — only char, wchar_t, char8_t, char16_t, and char32_t.

 Linux is already fine (TXChar = char16_t). The fix is to do the same on macOS in GSString.h:55:
// Before:
 typedef UniChar TXChar;
// After:
 typedef char16_t TXChar;

 This is safe because:
 - The public API only exposes MvrString (const char*) — no type change visible to consumers
 - char16_t and uint16_t are the same width and representation
 - It actually fixes a latent UB in TXString::hash(), which already casts to std::u16string
 - CoreFoundation calls expecting UniChar* just need an explicit cast