### PR TITLE
First step - adding new WheelSlot params

### DIFF
--- a/src/GDTFManager.cpp
+++ b/src/GDTFManager.cpp
@@ -1153,6 +1153,10 @@ GdtfWheelSlot::GdtfWheelSlot(GdtfWheel* parent)
 	fWheelParent 		= parent;
 	fFilter 	 		= nullptr;
 	fAnimationSystem	= nullptr;
+	fDuration			= 0.0;
+	fWidth				= 0;
+	fHeight				= 0;
+	fFPS				= 0;
 }
 
 GdtfWheelSlot::GdtfWheelSlot(const TXString& name, GdtfWheel* parent)
@@ -1161,6 +1165,10 @@ GdtfWheelSlot::GdtfWheelSlot(const TXString& name, GdtfWheel* parent)
 	fWheelParent 		= parent;
 	fFilter		 		= nullptr;
 	fAnimationSystem	= nullptr;
+	fDuration			= 0.0;
+	fWidth				= 0;
+	fHeight				= 0;
+	fFPS				= 0;
 }
 
 
@@ -1270,6 +1278,10 @@ void GdtfWheelSlot::OnPrintToFile(IXMLFileNodePtr pNode)
 	pNode->SetNodeAttributeValue(XML_GDTF_WheelSlotColor,		GdtfConverter::ConvertColor(fColor));
 	if(fGobo != "")	{ pNode->SetNodeAttributeValue(XML_GDTF_WheelSlotPicture,	fGobo); }
 	if(fFilter)	{ pNode->SetNodeAttributeValue(XML_GDTF_WheelSlotFilter,		fFilter->GetNodeReference()); }
+	if(fDuration != 0.0)	{ pNode->SetNodeAttributeValue(XML_GDTF_WheelSlotDuration,	GdtfConverter::ConvertDouble(fDuration)); }
+	if(fWidth != 0)			{ pNode->SetNodeAttributeValue(XML_GDTF_WheelSlotWidth,		GdtfConverter::ConvertInteger(fWidth)); }
+	if(fHeight != 0)		{ pNode->SetNodeAttributeValue(XML_GDTF_WheelSlotHeight,	GdtfConverter::ConvertInteger(fHeight)); }
+	if(fFPS != 0)			{ pNode->SetNodeAttributeValue(XML_GDTF_WheelSlotFPS,		GdtfConverter::ConvertInteger(fFPS)); }
 	
 	//------------------------------------------------------------------------------------
 	// Print the children
@@ -1311,6 +1323,16 @@ void GdtfWheelSlot::OnReadFromNode(const IXMLFileNodePtr& pNode)
 	
 
 	pNode->GetNodeAttributeValue(XML_GDTF_WheelSlotFilter,	fUnresolvedFilter);
+
+	TXString duration, width, height, fps;
+	pNode->GetNodeAttributeValue(XML_GDTF_WheelSlotDuration,	duration);
+	pNode->GetNodeAttributeValue(XML_GDTF_WheelSlotWidth,		width);
+	pNode->GetNodeAttributeValue(XML_GDTF_WheelSlotHeight,		height);
+	pNode->GetNodeAttributeValue(XML_GDTF_WheelSlotFPS,			fps);
+	if(!duration.IsEmpty())	{ GdtfConverter::ConvertDouble(duration,	pNode, fDuration); }
+	if(!width.IsEmpty())	{ GdtfConverter::ConvertInteger(width,		pNode, fWidth); }
+	if(!height.IsEmpty())	{ GdtfConverter::ConvertInteger(height,		pNode, fHeight); }
+	if(!fps.IsEmpty())		{ GdtfConverter::ConvertInteger(fps,		pNode, fFPS); }
 	
 	//------------------------------------------------------------------------------------
 	// Read the wheel slots
@@ -1358,6 +1380,10 @@ void GdtfWheelSlot::OnErrorCheck(const IXMLFileNodePtr& pNode)
 	optional.push_back(XML_GDTF_WheelSlotColor);
 	optional.push_back(XML_GDTF_WheelSlotPicture);
 	optional.push_back(XML_GDTF_WheelSlotFilter);
+	optional.push_back(XML_GDTF_WheelSlotDuration);
+	optional.push_back(XML_GDTF_WheelSlotWidth);
+	optional.push_back(XML_GDTF_WheelSlotHeight);
+	optional.push_back(XML_GDTF_WheelSlotFPS);
 
 	
 	//------------------------------------------------------------------------------------
@@ -1389,6 +1415,16 @@ GdtfWheelSlotAnimationSystem* GdtfWheelSlot::GetAnimationSystem() const
 {
 	return fAnimationSystem;
 }
+
+double GdtfWheelSlot::GetDuration() const { return fDuration; }
+size_t GdtfWheelSlot::GetWidth()    const { return fWidth; }
+size_t GdtfWheelSlot::GetHeight()   const { return fHeight; }
+size_t GdtfWheelSlot::GetFPS()      const { return fFPS; }
+
+void GdtfWheelSlot::SetDuration(double duration) { fDuration = duration; }
+void GdtfWheelSlot::SetWidth(size_t width)       { fWidth = width; }
+void GdtfWheelSlot::SetHeight(size_t height)     { fHeight = height; }
+void GdtfWheelSlot::SetFPS(size_t fps)           { fFPS = fps; }
 
 //------------------------------------------------------------------------------------
 // GdtfModel

--- a/src/GDTFManager.h
+++ b/src/GDTFManager.h
@@ -428,6 +428,10 @@ namespace SceneData
 		GdtfFilter*								fFilter;
 		TXString								fUnresolvedFilter;
 		GdtfWheelSlotAnimationSystem*			fAnimationSystem;
+		double									fDuration;
+		size_t									fWidth;
+		size_t									fHeight;
+		size_t									fFPS;
 		
 	public:
 		const TXString&							GetGobo() const;
@@ -437,6 +441,10 @@ namespace SceneData
         TGdtfWheelSlotPrismFacetArray			GetPrismFacets();
 		GdtfFilter*                 			GetFilter() const;
 		GdtfWheelSlotAnimationSystem*			GetAnimationSystem() const;
+		double									GetDuration() const;
+		size_t									GetWidth() const;
+		size_t									GetHeight() const;
+		size_t									GetFPS() const;
 		
 		void									SetName(const TXString& name);
 		void									SetGobo(const GdtfPNGFile& png);
@@ -444,6 +452,10 @@ namespace SceneData
 		void									SetFilter(GdtfFilter* filter);
 		GdtfWheelSlotPrismFacet*				AddPrismFacet();
 		GdtfWheelSlotAnimationSystem*			AddAnimationSystem();
+		void									SetDuration(double duration);
+		void									SetWidth(size_t width);
+		void									SetHeight(size_t height);
+		void									SetFPS(size_t fps);
 
 		virtual TXString						GetNodeReference();
 

--- a/src/Implementation/CGdtfWheelSlot.cpp
+++ b/src/Implementation/CGdtfWheelSlot.cpp
@@ -374,3 +374,59 @@ VectorworksMVR::VCOMError VectorworksMVR::CGdtfWheelSlotImpl::SetFilter (IGdtfFi
 
     return kVCOMError_NoError;
 }
+
+VectorworksMVR::VCOMError VectorworksMVR::CGdtfWheelSlotImpl::GetDuration(double& outDuration)
+{
+    if(!fWheelSlot) return kVCOMError_NotInitialized;
+    outDuration = fWheelSlot->GetDuration();
+    return kVCOMError_NoError;
+}
+
+VectorworksMVR::VCOMError VectorworksMVR::CGdtfWheelSlotImpl::GetWidth(size_t& outWidth)
+{
+    if(!fWheelSlot) return kVCOMError_NotInitialized;
+    outWidth = fWheelSlot->GetWidth();
+    return kVCOMError_NoError;
+}
+
+VectorworksMVR::VCOMError VectorworksMVR::CGdtfWheelSlotImpl::GetHeight(size_t& outHeight)
+{
+    if(!fWheelSlot) return kVCOMError_NotInitialized;
+    outHeight = fWheelSlot->GetHeight();
+    return kVCOMError_NoError;
+}
+
+VectorworksMVR::VCOMError VectorworksMVR::CGdtfWheelSlotImpl::GetFPS(size_t& outFPS)
+{
+    if(!fWheelSlot) return kVCOMError_NotInitialized;
+    outFPS = fWheelSlot->GetFPS();
+    return kVCOMError_NoError;
+}
+
+VectorworksMVR::VCOMError VectorworksMVR::CGdtfWheelSlotImpl::SetDuration(double duration)
+{
+    if(!fWheelSlot) return kVCOMError_NotInitialized;
+    fWheelSlot->SetDuration(duration);
+    return kVCOMError_NoError;
+}
+
+VectorworksMVR::VCOMError VectorworksMVR::CGdtfWheelSlotImpl::SetWidth(size_t width)
+{
+    if(!fWheelSlot) return kVCOMError_NotInitialized;
+    fWheelSlot->SetWidth(width);
+    return kVCOMError_NoError;
+}
+
+VectorworksMVR::VCOMError VectorworksMVR::CGdtfWheelSlotImpl::SetHeight(size_t height)
+{
+    if(!fWheelSlot) return kVCOMError_NotInitialized;
+    fWheelSlot->SetHeight(height);
+    return kVCOMError_NoError;
+}
+
+VectorworksMVR::VCOMError VectorworksMVR::CGdtfWheelSlotImpl::SetFPS(size_t fps)
+{
+    if(!fWheelSlot) return kVCOMError_NotInitialized;
+    fWheelSlot->SetFPS(fps);
+    return kVCOMError_NoError;
+}

--- a/src/Implementation/CGdtfWheelSlot.h
+++ b/src/Implementation/CGdtfWheelSlot.h
@@ -32,6 +32,15 @@ namespace VectorworksMVR
 
         virtual VCOMError VCOM_CALLTYPE     GetAnimationSystem(IGdtfWheelSlotAnimationSystem** outAnimationSystem);
 		virtual VCOMError VCOM_CALLTYPE     CreateAnimationSystem(double p1_X, double p1_Y, double p2_X, double p2_Y, double p3_X, double p3_Y, double radius, IGdtfWheelSlotAnimationSystem**   outAnimationSystem);
+
+		virtual VCOMError VCOM_CALLTYPE     GetDuration(double& outDuration);
+		virtual VCOMError VCOM_CALLTYPE     GetWidth(size_t& outWidth);
+		virtual VCOMError VCOM_CALLTYPE     GetHeight(size_t& outHeight);
+		virtual VCOMError VCOM_CALLTYPE     GetFPS(size_t& outFPS);
+		virtual VCOMError VCOM_CALLTYPE     SetDuration(double duration);
+		virtual VCOMError VCOM_CALLTYPE     SetWidth(size_t width);
+		virtual VCOMError VCOM_CALLTYPE     SetHeight(size_t height);
+		virtual VCOMError VCOM_CALLTYPE     SetFPS(size_t fps);
 		
 		virtual VCOMError VCOM_CALLTYPE     BindToObject(void* objAddr);
 		virtual void*	  VCOM_CALLTYPE     GetBoundObject();

--- a/src/Include/IMediaRessourceVectorInterface.h
+++ b/src/Include/IMediaRessourceVectorInterface.h
@@ -684,6 +684,16 @@ namespace VectorworksMVR
 		//GDTF 1.1
 		virtual VCOMError VCOM_CALLTYPE     GetAnimationSystem(IGdtfWheelSlotAnimationSystem** outAnimationSystem) = 0;
 		virtual VCOMError VCOM_CALLTYPE     CreateAnimationSystem(double p1_X, double p1_Y, double p2_X, double p2_Y, double p3_X, double p3_Y, double radius, IGdtfWheelSlotAnimationSystem** 	outAnimationSystem) = 0;
+
+		// Spec PR #305 - Media content attributes
+		virtual VCOMError VCOM_CALLTYPE     GetDuration(double& outDuration) = 0;
+		virtual VCOMError VCOM_CALLTYPE     GetWidth(size_t& outWidth) = 0;
+		virtual VCOMError VCOM_CALLTYPE     GetHeight(size_t& outHeight) = 0;
+		virtual VCOMError VCOM_CALLTYPE     GetFPS(size_t& outFPS) = 0;
+		virtual VCOMError VCOM_CALLTYPE     SetDuration(double duration) = 0;
+		virtual VCOMError VCOM_CALLTYPE     SetWidth(size_t width) = 0;
+		virtual VCOMError VCOM_CALLTYPE     SetHeight(size_t height) = 0;
+		virtual VCOMError VCOM_CALLTYPE     SetFPS(size_t fps) = 0;
     };
 	typedef VCOMPtr<IGdtfWheelSlot>	IGdtfWheelSlotPtr;
     

--- a/src/Prefix/CommonPrefix.h
+++ b/src/Prefix/CommonPrefix.h
@@ -390,6 +390,10 @@ const Sint32 kGDTF_CurrentMinorVersion = 2;
 #define XML_GDTF_WheelSlotColor			"Color"
 #define XML_GDTF_WheelSlotPicture		"MediaFileName"
 #define XML_GDTF_WheelSlotFilter		"Filter"
+#define XML_GDTF_WheelSlotDuration		"Duration"
+#define XML_GDTF_WheelSlotWidth			"Width"
+#define XML_GDTF_WheelSlotHeight		"Height"
+#define XML_GDTF_WheelSlotFPS			"FPS"
 
 #define XML_GDTF_PrismFacetNodeName		"Facet"
 #define XML_GDTF_PrismFacetColor		"Color"

--- a/unittest/GdtfUnittest.cpp
+++ b/unittest/GdtfUnittest.cpp
@@ -194,6 +194,11 @@ void GdtfUnittest::WriteFile()
 				IGdtfWheelSlotAnimationSystemPtr gdtfAnimationSystem;
 				__checkVCOM(wheelSlotContainer->CreateAnimationSystem(1.0, 1.5, 2.0, 2.5, 3.0, 3.5, 4.0 /*radius*/, &gdtfAnimationSystem));
 
+				// Set media content attributes (Spec PR #305)
+				__checkVCOM(wheelSlotContainer->SetDuration(12.345));
+				__checkVCOM(wheelSlotContainer->SetWidth(1920));
+				__checkVCOM(wheelSlotContainer->SetHeight(1080));
+				__checkVCOM(wheelSlotContainer->SetFPS(30));
 
 				// Set Filter link
 				__checkVCOM(wheelSlotContainer->SetFilter(gdtfFilter));
@@ -670,6 +675,18 @@ void GdtfUnittest::ReadFile()
 							this->checkifEqual("GetWheelSlotAnimationSystemRadius ", radius, 4.0);
 
 						}
+
+						// Media content attributes (Spec PR #305)
+						double duration = 0.0;
+						size_t width = 0, height = 0, fps = 0;
+						__checkVCOM(gdtfSlot->GetDuration(duration));
+						__checkVCOM(gdtfSlot->GetWidth(width));
+						__checkVCOM(gdtfSlot->GetHeight(height));
+						__checkVCOM(gdtfSlot->GetFPS(fps));
+						this->checkifEqual("GetWheelSlotDuration ", duration, 12.345);
+						this->checkifEqual("GetWheelSlotWidth ",    width,    size_t(1920));
+						this->checkifEqual("GetWheelSlotHeight ",   height,   size_t(1080));
+						this->checkifEqual("GetWheelSlotFPS ",      fps,      size_t(30));
 
 					} // WheelSlot loop
 				}


### PR DESCRIPTION
# Wheel Slot: media content attributes (Spec PR #305)

Implements [mvrdevelopment/spec#305](https://github.com/mvrdevelopment/spec/pull/305) — extends `GdtfWheelSlot` with four optional XML attributes for describing animated/video gobo media content.

## Changes

| Attribute | Type | XML name | Default |
|-----------|------|----------|---------|
| Duration  | `double` (seconds) | `Duration` | `0.0` |
| Width     | `size_t` (pixels)  | `Width`    | `0`   |
| Height    | `size_t` (pixels)  | `Height`   | `0`   |
| FPS       | `size_t`           | `FPS`      | `0`   |

All four attributes are optional and are only written to XML when non-zero/non-default.

## Files modified

- `src/Prefix/CommonPrefix.h` — 4 new XML constants
- `src/GDTFManager.h` — private fields + getter/setter declarations on `GdtfWheelSlot`
- `src/GDTFManager.cpp` — constructor init, XML read/write, error check, getter/setter bodies
- `src/Include/IMediaRessourceVectorInterface.h` — 8 pure virtual methods on `IGdtfWheelSlot`
- `src/Implementation/CGdtfWheelSlot.h` — method declarations
- `src/Implementation/CGdtfWheelSlot.cpp` — method implementations
- `unittest/GdtfUnittest.cpp` — write + read-back assertions for all 4 attributes
