### PR TITLE
Change deallocation method to use free

### DIFF
--- a/src/GSString.h
+++ b/src/GSString.h
@@ -97,7 +97,7 @@ public:
 	// Deallocation
 	void deallocate(pointer p, size_type)
 	{
-		delete p;
+		free(p);
 	}
 
 	// Construction


### PR DESCRIPTION
Changed memory deallocation method from 'delete' to 'free'.
`allocate` uses `malloc` so `deallocate` MUST not use `delete`! It MUST use a matching `free`.

```
// Allocation
pointer allocate(size_type num, const void* hint = 0)
{
	return (pointer)malloc(num * sizeof(T));
}

// Deallocation
void deallocate(pointer p, size_type)
{
	free(p);
}

```