### PR TITLE
Initialize fRefCnt in rapidxml XML file implementations

### DIFF
--- a/src/rapidxmlsupport/XMLFileImpl.cpp
+++ b/src/rapidxmlsupport/XMLFileImpl.cpp
@@ -16,6 +16,7 @@ using namespace VectorworksMVR::VWFC::Tools;
 // ----------------------------------------------------------------------------------------------------
 CXMLFileImpl::CXMLFileImpl()
 {
+	fRefCnt = 0;
 }
 
 CXMLFileImpl::~CXMLFileImpl()

--- a/src/rapidxmlsupport/XMLFileNodeImpl.cpp
+++ b/src/rapidxmlsupport/XMLFileNodeImpl.cpp
@@ -14,6 +14,7 @@ using namespace VectorworksMVR::VWFC::Tools;
 CXMLFileNodeImpl::CXMLFileNodeImpl()
 {
 	fElement = nullptr;
+	fRefCnt  = 0;
 }
 
 CXMLFileNodeImpl::~CXMLFileNodeImpl()


### PR DESCRIPTION
## Problem

`CXMLFileImpl` and `CXMLFileNodeImpl` (rapidxmlsupport, used with `DONT_USE_XERCES_AS_XMLLIB`) implement `IVWUnknown` reference counting manually, but their constructors never initialize `fRefCnt`. The member starts with whatever the allocator returns.

## Effects

- On typical glibc heaps the garbage value is non-zero, so the count never reaches 0 in `Release()` and every XML file/node object is **leaked silently**.
- On allocators that hand out zeroed pages (e.g. a fresh WebAssembly/Emscripten heap, where we found this while porting the library), `Release()` is entered with `fRefCnt == 0` and prints the `fRefCnt > 0` assert for every single node while parsing — thousands of lines per GDTF/MVR file.

## Fix

Initialize `fRefCnt = 0` in both constructors, matching what `VCOMImpl<T>` does for all other implementations.

Verified by parsing all files from gdtf-share samples with the rapidxml backend: no assert output, objects are correctly destroyed.
