### PR TITLE
Add Emscripten/WebAssembly support

### DIFF
--- a/src/UUID.cpp
+++ b/src/UUID.cpp
@@ -6,7 +6,10 @@
 
 #include "Prefix/StdAfx.h"
 
-#if _LINUX
+#if defined(__EMSCRIPTEN__)
+	// Emscripten/WASM: no libuuid available, we generate random (v4) UUIDs
+	#include <random>
+#elif _LINUX
 	// If this include fails, run this command to install it:
 	// sudo apt-get install uuid-dev
 	#include <uuid/uuid.h>
@@ -309,6 +312,17 @@ void VWFC::Tools::VWUUID::New()
 	fData[13]			= guid.Data4[5];
 	fData[14]			= guid.Data4[6];
 	fData[15]			= guid.Data4[7];
+#elif defined(__EMSCRIPTEN__)
+	// Generate a random (version 4) UUID.
+	// std::random_device maps to a secure entropy source in Emscripten
+	{
+		std::random_device rd;
+		std::uniform_int_distribution<unsigned int> dist(0, 255);
+		for (size_t i = 0; i < 16; i++) { fData[i] = (Uint8)dist(rd); }
+
+		fData[6] = (Uint8)((fData[6] & 0x0F) | 0x40);	// version 4
+		fData[8] = (Uint8)((fData[8] & 0x3F) | 0x80);	// variant 10xx
+	}
 #elif _LINUX
 	uuid_t myUUID;
 	uuid_generate_time_safe( myUUID );

--- a/src/Wrapper/FilingWrapper.cpp
+++ b/src/Wrapper/FilingWrapper.cpp
@@ -396,6 +396,12 @@ bool VectorworksMVR::Filing::GetFolderAppDataPath(TXString& outPath)
 	
 	if(!result) return false;
 	outPath = TXString(buffer);
+#elif defined(__EMSCRIPTEN__)
+	// Emscripten/WASM: getpwuid() returns NULL; use $HOME or the default
+	// MEMFS home directory instead
+	const char* homedir = getenv("HOME");
+	if (homedir == nullptr || homedir[0] == 0) { homedir = "/home/web_user"; }
+	outPath = TXString(homedir);
 #elif _LINUX
 	// LINUX_IMPLEMENTATION - done
 	struct passwd *pw = getpwuid(getuid());

--- a/src/XmlFileHelper.cpp
+++ b/src/XmlFileHelper.cpp
@@ -399,7 +399,7 @@ bool SceneData::GdtfConverter::ConvertColorArray(TXString values, const IXMLFile
 	return valueStr;
 }
 
-#ifdef IS64BIT
+#if defined(IS64BIT) || defined(__EMSCRIPTEN__)
 /*static*/ TXString GdtfConverter::ConvertInteger(Uint32 value)
 {
 	TXString valueStr;
@@ -449,7 +449,7 @@ bool SceneData::GdtfConverter::ConvertColorArray(TXString values, const IXMLFile
 	return true;
 }
 
-#ifdef IS64BIT
+#if defined(IS64BIT) || defined(__EMSCRIPTEN__)
 /*static*/ bool GdtfConverter::ConvertInteger(const TXString& value, const IXMLFileNodePtr& node, Uint32& intValue)
 {
     if(value.IsEmpty()) return false;

--- a/src/XmlFileHelper.h
+++ b/src/XmlFileHelper.h
@@ -62,7 +62,7 @@ namespace SceneData
 		static TXString	ConvertDouble(double value);
 		static TXString	ConvertDoubleArray(TDoubleArray& values, bool includeBrackets);
 		static TXString	ConvertInteger(Sint32 value);
-#ifdef IS64BIT
+#if defined(IS64BIT) || defined(__EMSCRIPTEN__)
 		static TXString	ConvertInteger(Uint32 value);
 #endif
         static TXString	ConvertDmxBreak(Sint32 value);
@@ -118,7 +118,7 @@ namespace SceneData
 		static bool		ConvertPrimitiveType(			const TXString& value, const IXMLFileNodePtr& node,	EGdtfModel_PrimitiveType& type);
 		static bool		ConvertLampeType(				const TXString& value, const IXMLFileNodePtr& node,	EGdtfLampType& lampType);
 		static bool		ConvertInteger(					const TXString& value, const IXMLFileNodePtr& node,	Sint32&	intValue);
-#ifdef IS64BIT
+#if defined(IS64BIT) || defined(__EMSCRIPTEN__)
 		static bool		ConvertInteger(					const TXString& value, const IXMLFileNodePtr& node,	Uint32&	intValue);
 #endif
         static bool		ConvertDmxBreak(				const TXString& value, const IXMLFileNodePtr& node,	Sint32&	intValue);


### PR DESCRIPTION
## Motivation

This makes libMVRgdtf compile and run correctly as WebAssembly with Emscripten, so the reference implementation can be used directly in browsers (and Node.js) with 100% file compatibility — e.g. for web-based GDTF/MVR viewers and visualizers — instead of re-implementing the formats in JS.

The library builds with the `GS_LIN`/`_LINUX` platform macros, `DONT_USE_XERCES_AS_XMLLIB` (bundled tinyxml2/rapidxml) and without `BUILD_MVR_XCHANGE` (raw TCP/mDNS is not available in a browser sandbox). Only three small platform issues needed changes:

## Changes

- **`UUID.cpp`** — Emscripten has no libuuid and no `/proc`. Under `__EMSCRIPTEN__`, generate random (version 4) UUIDs using `std::random_device`, which maps to a secure entropy source in Emscripten.

- **`Wrapper/FilingWrapper.cpp`** — `getpwuid()` returns `NULL` under Emscripten, so `GetFolderAppDataPath` dereferenced a null pointer and produced an invalid path (which broke the working-folder extraction of GDTF/MVR archives). Use `$HOME` with a fallback to `/home/web_user`, the default MEMFS home directory.

- **`XmlFileHelper.{h,cpp}`** — wasm32 defines `size_t` as `unsigned long`, which is a distinct type from `Uint32` (`unsigned int`) even though both are 32-bit — unlike the 32-bit targets the `IS64BIT` guard was written for. Compile the `Uint32` overloads of `ConvertInteger` under Emscripten as well; otherwise calls with `Uint32` arguments (e.g. `GdtfMap::OnPrintToFile`, `GdtfConnector::OnReadFromNode`) are ambiguous and fail to compile.

All changes are guarded by `__EMSCRIPTEN__` and do not affect any existing platform.

## Testing

Built with Emscripten 6.0.3 (`-fwasm-exceptions`, embind bindings on top) and verified in Node.js and headless Chrome:

- All gdtf-share sample fixtures (Ayrton, BETOPPER, …) and several MVR show files (grandMA3 demo show, festival rigs, 15 files total) parse with zero `GetParsingErrorCount()`, identical results to the native Linux build
- Full round trip of fixture metadata, DMX modes/channels, geometry trees (incl. glTF/3DS model buffer extraction), MVR scene traversal with GDTF resolution and DMX addresses

Note: for a fully working WASM build, the pending fixes #169 (root node name) and #170 (3DS/SVG buffer null check) are also needed, but they are independent of this PR.
